### PR TITLE
WIP -Add changes to include action mask

### DIFF
--- a/envs/rogi_rl_param_action.py
+++ b/envs/rogi_rl_param_action.py
@@ -1,0 +1,99 @@
+from rogi_rl import RogiSimEnv
+from gym import spaces  # , wrappers
+import numpy as np
+
+from rogi_rl.agent_state import AgentState
+import gym
+from gym.spaces import Box, MultiDiscrete, Dict  # Discrete
+
+from rogi_rl.env import ActionType
+
+
+class RogiRlWrapper(RogiSimEnv):
+
+    def __init__(self, env_config):
+        super().__init__(env_config)
+        self.observation_space = spaces.Box(
+            low=np.int8(0),
+            high=np.int8(1),
+            shape=(
+                self.width *
+                self.height *
+                len(AgentState),))
+
+    def reset(self):
+        obs = super().reset()
+        return obs.flatten()
+
+    def step(self, action):
+        _observation, _step_reward, _done, _info = super().step(action)
+        return _observation.flatten(), _step_reward, _done, _info
+
+        # TODO : Add Observation Preprocessor in wrapper or Reward Hacking
+
+
+class RogiRlParamAction(gym.Env):
+    """Parametric action version.
+
+    In this env there is a multi-discrete actions
+                with [len(ActionType, width, height]
+    Total_Size = len(ActionType) + width + height
+
+    We have 2 action types STEP and VACCINATE supported currently
+
+    logits[:len(ActionType)] corresponds to the logits for step, vaccinate
+    logits[len(ActionType):width + len(ActionType)] are logits for X Coordinate
+    logits[width + len(ActionType):] are logits for Y Coordinate
+
+    Currently we support masking based on the vaccinate cell if non-susceptible
+
+    At each step, we emit a dict of:
+        - the actual observation
+        - a mask of valid actions (e.g., [0, 0, 1, ...n]
+                                   for `n` max avail actions)
+    """
+
+    def __init__(self, env_config={}):
+
+        self.wrapped = RogiRlWrapper(env_config)
+        self.observation_space = Dict({
+            "action_mask": Box(np.int8(0), np.int8(1),
+                               shape=(1, self.wrapped.width,
+                                      self.wrapped.height,)),
+            "rogi": Box(low=np.float32(0),
+                        high=np.float32(1),
+                        shape=(
+                            self.wrapped.width *
+                            self.wrapped.height *
+                            len(AgentState),))
+        })
+        self.action_space = MultiDiscrete(
+            [
+                len(ActionType), self.wrapped.width, self.wrapped.height
+            ])
+
+    def update_avail_actions(self, orig_obs, flattened=True):
+        width, height = self.wrapped.width, self.wrapped.height
+        self.action_mask = np.zeros((1, width, height))
+        if flattened:
+            orig_obs = orig_obs.reshape(width, height, len(AgentState))
+        for i in range(self.action_mask.shape[0]):
+            # TODO: Support for batch - vectorize with Observation
+            self.action_mask[i] = orig_obs[:, :, AgentState.SUSCEPTIBLE.value]
+
+    def reset(self):
+        orig_obs = self.wrapped.reset()
+        self.update_avail_actions(orig_obs, True)
+        return {
+            "action_mask": self.action_mask,
+            "rogi": orig_obs,
+        }
+
+    def step(self, action):
+        orig_obs, rew, done, info = self.wrapped.step(action)
+        self.update_avail_actions(orig_obs)
+        obs = {
+            "action_mask": self.action_mask,
+            "rogi": orig_obs,
+        }
+        return obs, rew, done, info

--- a/experiments/rogi-rl-mask-0.yaml
+++ b/experiments/rogi-rl-mask-0.yaml
@@ -1,0 +1,37 @@
+rogi-rl-mask-ppo:
+    env: rogi_rl_param_action
+    run: PPO
+    stop:
+        time_total_s: 1500
+    config:
+        model:
+            custom_model: param_action_model
+            vf_share_layers: True
+        num_workers: 1
+        eager: True,
+        log_level: INFO
+        # num_sgd_iter: 1
+        sgd_minibatch_size: 1
+        rollout_fragment_length: 1
+        train_batch_size: 1
+        env_config:
+            width: 5
+            height: 5
+            population_density: 1.0
+            vaccine_density: 0.66
+            initial_infection_fraction: 0.045
+            initial_vaccination_fraction: 0.00
+            prob_infection: 0.05
+            prob_agent_movement: 0.0
+            disease_planner_config: 
+                latent_period_mu:   8 # 2 * 4
+                latent_period_sigma:   0
+                incubation_period_mu:   20 # 5 * 4
+                incubation_period_sigma:   0
+                recovery_period_mu:   56 # 14 * 4
+                recovery_period_sigma:   0
+            max_simulation_timesteps: 200
+            early_stopping_patience: 14
+            use_renderer: False
+            toric: False
+            debug: False

--- a/experiments/rogi-rl-mask-0.yaml
+++ b/experiments/rogi-rl-mask-0.yaml
@@ -8,7 +8,7 @@ rogi-rl-mask-ppo:
             custom_model: param_action_model
             vf_share_layers: True
         num_workers: 1
-        eager: True,
+        # eager: True,
         log_level: INFO
         # num_sgd_iter: 1
         sgd_minibatch_size: 1

--- a/models/param_action_model.py
+++ b/models/param_action_model.py
@@ -33,42 +33,65 @@ class ParamActionModel(TFModelV2):
 
     def forward(self, input_dict, state, seq_lens):
         # Extract the available actions tensor from the observation.
+        float_tf_type = tf.float32
         action_mask = input_dict["obs"]["action_mask"]
 
         # Compute the predicted action embedding
         action_embed_orig, _ = self.action_embed_model({
             "obs": input_dict["obs"]["rogi"]
         })
+        action_embed_orig = tf.cast(action_embed_orig, float_tf_type)
+        action_mask = tf.cast(action_mask, float_tf_type)
+
         action_dims = self.action_space.nvec
         num_outputs = sum(action_dims)
         width = action_dims[1]
 
         action_embed = tf.squeeze(action_embed_orig)
-        action_mask_actual = np.array([1.] * num_outputs)
+        action_mask_actual = tf.constant([1.]*num_outputs,
+                                         dtype=float_tf_type)
+
         action_mask = tf.squeeze(action_mask)
         n_action_types = len(ActionType)
-        end_x = width + n_action_types
+        end_x = n_action_types + width
         action_type = tf.argmax(action_embed[:n_action_types], axis=-1)
         cell_x = tf.argmax(action_embed[n_action_types:end_x], axis=-1)
         cell_y = tf.argmax(action_embed[end_x:], axis=-1)
 
         action_mask_value = action_mask[cell_x, cell_y]
 
-        if(int(action_type) == 1):
-            # Change vaccination to Step
-            cell_x_idx = n_action_types + cell_x
-            cell_y_idx = n_action_types + width + cell_y
-            if int(action_mask_value) == 0:
-                action_mask_actual[1] = 0  # Disable Vaccinate
-                action_mask_actual[cell_x_idx] = 0  # Mask Cell X
-                action_mask_actual[cell_y_idx] = 0  # Mask Cell Y
+        cell_x_idx = tf.add(tf.constant([n_action_types],
+                            dtype=cell_x.dtype), cell_x)
+        cell_y_idx = tf.add(tf.constant([end_x], dtype=cell_y.dtype), cell_y)
+        vaccinate_idx = tf.constant([ActionType.VACCINATE.value],
+                                    dtype=cell_x.dtype)
+
+        vaccinate_idx = tf.cast(vaccinate_idx, tf.int32)
+        cell_x_idx = tf.cast(cell_x_idx, tf.int32)
+        cell_y_idx = tf.cast(cell_y_idx, tf.int32)
+        indices = tf.stack(values=[vaccinate_idx,
+                                   cell_x_idx, cell_y_idx], axis=0)
+        updates = tf.constant([1, 1, 1])
+        shape = tf.constant([num_outputs])
+        masker = tf.scatter_nd(indices, updates, shape)
+
+        masker = tf.cast(masker, float_tf_type)
+
+        action_mask_vaccinate = tf.cond(tf.equal(action_mask_value, 1),
+                                        lambda: action_mask_actual,
+                                        lambda: action_mask_actual - masker)
+
+        action_mask_actual = tf.cond(tf.equal(action_type,
+                                     ActionType.VACCINATE.value),
+                                     lambda: action_mask_vaccinate,
+                                     lambda: action_mask_actual)
 
         action_logits = action_embed_orig
 
-        # Mask out invalid actions (use tf.float32.min for stability)
-        action_mask_actual = tf.constant(action_mask_actual, dtype=tf.float32)
+        # Mask out invalid actions (use tf.float32.min for stability
         inf_mask = tf.maximum(tf.log(action_mask_actual),
-                              tf.float32.min)
+                              float_tf_type.min)
+
         inf_mask = tf.expand_dims(inf_mask, 0)
 
         action_logits_updated = action_logits + inf_mask

--- a/models/param_action_model.py
+++ b/models/param_action_model.py
@@ -1,0 +1,78 @@
+import numpy as np
+from rogi_rl.agent_state import AgentState
+from rogi_rl.env import ActionType
+from gym.spaces import Box
+
+from ray.rllib.models.tf.fcnet_v2 import FullyConnectedNetwork
+from ray.rllib.models.tf.tf_modelv2 import TFModelV2
+from ray.rllib.utils import try_import_tf
+
+tf = try_import_tf()
+
+
+class ParamActionModel(TFModelV2):
+    """Parametric action model that handles the dot product and masking.
+    """
+
+    def __init__(self,
+                 obs_space,
+                 action_space,
+                 num_outputs,
+                 model_config,
+                 name,
+                 **kw):
+        super(ParamActionModel, self).__init__(
+            obs_space, action_space, num_outputs, model_config, name, **kw)
+        action_dims = self.action_space.nvec
+        self.action_embed_model = FullyConnectedNetwork(
+            Box(np.float32(0), np.float32(1), shape=(action_dims[1] *
+                                                     action_dims[2] *
+                                                     len(AgentState),)),
+            action_space, num_outputs, model_config, name + "_action_mask")
+        self.register_variables(self.action_embed_model.variables())
+
+    def forward(self, input_dict, state, seq_lens):
+        # Extract the available actions tensor from the observation.
+        action_mask = input_dict["obs"]["action_mask"]
+
+        # Compute the predicted action embedding
+        action_embed_orig, _ = self.action_embed_model({
+            "obs": input_dict["obs"]["rogi"]
+        })
+        action_dims = self.action_space.nvec
+        num_outputs = sum(action_dims)
+        width = action_dims[1]
+
+        action_embed = tf.squeeze(action_embed_orig)
+        action_mask_actual = np.array([1.] * num_outputs)
+        action_mask = tf.squeeze(action_mask)
+        n_action_types = len(ActionType)
+        end_x = width + n_action_types
+        action_type = tf.argmax(action_embed[:n_action_types], axis=-1)
+        cell_x = tf.argmax(action_embed[n_action_types:end_x], axis=-1)
+        cell_y = tf.argmax(action_embed[end_x:], axis=-1)
+
+        action_mask_value = action_mask[cell_x, cell_y]
+
+        if(int(action_type) == 1):
+            # Change vaccination to Step
+            cell_x_idx = n_action_types + cell_x
+            cell_y_idx = n_action_types + width + cell_y
+            if int(action_mask_value) == 0:
+                action_mask_actual[1] = 0  # Disable Vaccinate
+                action_mask_actual[cell_x_idx] = 0  # Mask Cell X
+                action_mask_actual[cell_y_idx] = 0  # Mask Cell Y
+
+        action_logits = action_embed_orig
+
+        # Mask out invalid actions (use tf.float32.min for stability)
+        action_mask_actual = tf.constant(action_mask_actual, dtype=tf.float32)
+        inf_mask = tf.maximum(tf.log(action_mask_actual),
+                              tf.float32.min)
+        inf_mask = tf.expand_dims(inf_mask, 0)
+
+        action_logits_updated = action_logits + inf_mask
+        return action_logits_updated, state
+
+    def value_function(self):
+        return self.action_embed_model.value_function()

--- a/models/param_action_model.py
+++ b/models/param_action_model.py
@@ -34,12 +34,16 @@ class ParamActionModel(TFModelV2):
     def forward(self, input_dict, state, seq_lens):
         # Extract the available actions tensor from the observation.
         float_tf_type = tf.float32
+        int_tf_type = tf.int32
         action_mask = input_dict["obs"]["action_mask"]
 
         # Compute the predicted action embedding
         action_embed_orig, _ = self.action_embed_model({
             "obs": input_dict["obs"]["rogi"]
         })
+
+        # Standardise all tf types to tf.float32 to avoid issues
+        # in any tensorflow operations involving different types
         action_embed_orig = tf.cast(action_embed_orig, float_tf_type)
         action_mask = tf.cast(action_mask, float_tf_type)
 
@@ -48,27 +52,39 @@ class ParamActionModel(TFModelV2):
         width = action_dims[1]
 
         action_embed = tf.squeeze(action_embed_orig)
+
+        # action_mask_actual represents the final mask
+        # that will be added to our logits after taking log
         action_mask_actual = tf.constant([1.]*num_outputs,
                                          dtype=float_tf_type)
 
         action_mask = tf.squeeze(action_mask)
+
         n_action_types = len(ActionType)
         end_x = n_action_types + width
         action_type = tf.argmax(action_embed[:n_action_types], axis=-1)
         cell_x = tf.argmax(action_embed[n_action_types:end_x], axis=-1)
         cell_y = tf.argmax(action_embed[end_x:], axis=-1)
 
+        # get the value of susceptible observation for our x,y
         action_mask_value = action_mask[cell_x, cell_y]
 
+        # Start Index of the logits for x-coordinate
         cell_x_idx = tf.add(tf.constant([n_action_types],
                             dtype=cell_x.dtype), cell_x)
+
+        # Start Index of the logits for y-coordinate
         cell_y_idx = tf.add(tf.constant([end_x], dtype=cell_y.dtype), cell_y)
+
         vaccinate_idx = tf.constant([ActionType.VACCINATE.value],
                                     dtype=cell_x.dtype)
 
-        vaccinate_idx = tf.cast(vaccinate_idx, tf.int32)
-        cell_x_idx = tf.cast(cell_x_idx, tf.int32)
-        cell_y_idx = tf.cast(cell_y_idx, tf.int32)
+        # Cast all tensors to our tf int standard
+        vaccinate_idx = tf.cast(vaccinate_idx, int_tf_type)
+        cell_x_idx = tf.cast(cell_x_idx, int_tf_type)
+        cell_y_idx = tf.cast(cell_y_idx, int_tf_type)
+
+        # Update masks in the x,y and vaccinate indexes
         indices = tf.stack(values=[vaccinate_idx,
                                    cell_x_idx, cell_y_idx], axis=0)
         updates = tf.constant([1, 1, 1])
@@ -77,15 +93,18 @@ class ParamActionModel(TFModelV2):
 
         masker = tf.cast(masker, float_tf_type)
 
+        # Masked values in case of vaccinate
         action_mask_vaccinate = tf.cond(tf.equal(action_mask_value, 1),
                                         lambda: action_mask_actual,
                                         lambda: action_mask_actual - masker)
 
+        # Use vaccinate masked values only if action type is vaccinate
         action_mask_actual = tf.cond(tf.equal(action_type,
                                      ActionType.VACCINATE.value),
                                      lambda: action_mask_vaccinate,
                                      lambda: action_mask_actual)
 
+        # TODO: Placeholder for including action emebedings
         action_logits = action_embed_orig
 
         # Mask out invalid actions (use tf.float32.min for stability


### PR DESCRIPTION
Currently this is working but the results seems to be stable and then change only after remaining constant for some time (This has been checked only for beginning steps).  Little bit detailed look at some values may be necessary.

It is currently working only in eager mode.. Small changes have to be made to remove any numpy/other core python operations to enable eager false.
Also batch size of 1 only supported as of now.
We have done this only for the currently supported flattened observation.
Custom Wrapper for flattened observation was written as the preprocessor does not seem to be supported in Rllib with parametric actions
